### PR TITLE
Add S3 type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ You can then request the fixture in your tests and ensure you have the nessecary
 - [ ] Route53RecoveryControlConfig
 - [ ] Route53RecoveryReadiness
 - [ ] Route53Resolver
-- [ ] S3 (WIP)
+- [x] S3
 - [ ] S3Control
 - [ ] S3Outposts
 - [ ] SageMaker

--- a/bearboto3/s3.py
+++ b/bearboto3/s3.py
@@ -26,64 +26,153 @@ else:
 
     from bearboto3 import Annotated
 
-    BucketExistsWaiter = Annotated[Waiter, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.BucketExists"]]]]
+    BucketExistsWaiter = Annotated[
+        Waiter,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.BucketExists"]]],
+    ]
     BucketNotExistsWaiter = Annotated[
-        Waiter, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.BucketNotExists"]]]
+        Waiter,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.BucketNotExists"]]],
     ]
     ListMultipartUploadsPaginator = Annotated[
-        Paginator, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListMultipartUploads"]]]
+        Paginator,
+        IsAttr[
+            "__class__",
+            IsAttr["__name__", IsEqual["S3.Paginator.ListMultipartUploads"]],
+        ],
     ]
     ListObjectVersionsPaginator = Annotated[
-        Paginator, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListObjectVersions"]]]
+        Paginator,
+        IsAttr[
+            "__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListObjectVersions"]]
+        ],
     ]
     ListObjectsPaginator = Annotated[
-        Paginator, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListObjects"]]]
+        Paginator,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListObjects"]]],
     ]
     ListObjectsV2Paginator = Annotated[
-        Paginator, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListObjectsV2"]]]
+        Paginator,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListObjectsV2"]]],
     ]
-    ListPartsPaginator = Annotated[Paginator, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListParts"]]]]
-    ObjectExistsWaiter = Annotated[Waiter, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.ObjectExists"]]]]
+    ListPartsPaginator = Annotated[
+        Paginator,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Paginator.ListParts"]]],
+    ]
+    ObjectExistsWaiter = Annotated[
+        Waiter,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.ObjectExists"]]],
+    ]
     ObjectNotExistsWaiter = Annotated[
-        Waiter, IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.ObjectNotExists"]]]
+        Waiter,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["S3.Waiter.ObjectNotExists"]]],
     ]
-    S3Client = Annotated[BaseClient, IsAttr["__class__", IsAttr["__name__", IsEqual["S3"]]]]
-    S3ServiceResource = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ServiceResource"]]]]
+    S3Client = Annotated[
+        BaseClient, IsAttr["__class__", IsAttr["__name__", IsEqual["S3"]]]
+    ]
+    S3ServiceResource = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ServiceResource"]]],
+    ]
 
-    Bucket = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Bucket"]]]]
-    BucketAcl = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketAcl"]]]]
-    BucketCors = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketCors"]]]]
-    BucketLifecycle = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketLifecycle"]]]]
+    Bucket = Annotated[
+        ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Bucket"]]]
+    ]
+    BucketAcl = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketAcl"]]],
+    ]
+    BucketCors = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketCors"]]],
+    ]
+    BucketLifecycle = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketLifecycle"]]],
+    ]
     BucketLifecycleConfiguration = Annotated[
-        ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketLifecycleConfiguration"]]]
+        ServiceResource,
+        IsAttr[
+            "__class__", IsAttr["__name__", IsEqual["s3.BucketLifecycleConfiguration"]]
+        ],
     ]
-    BucketLogging = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketLogging"]]]]
-    BucketNotification = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketNotification"]]]]
-    BucketPolicy = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketPolicy"]]]]
+    BucketLogging = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketLogging"]]],
+    ]
+    BucketNotification = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketNotification"]]],
+    ]
+    BucketPolicy = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketPolicy"]]],
+    ]
     BucketRequestPayment = Annotated[
-        ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketRequestPayment"]]]
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketRequestPayment"]]],
     ]
-    BucketTagging = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketTagging"]]]]
-    BucketVersioning = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketVersioning"]]]]
-    BucketWebsite = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketWebsite"]]]]
-    MultipartUpload = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.MultipartUpload"]]]]
-    MultipartUploadPart = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.MultipartUploadPart"]]]]
-    Object = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Object"]]]]
-    ObjectAcl = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ObjectAcl"]]]]
-    ObjectSummary = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ObjectSummary"]]]]
-    ObjectVersion = Annotated[ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ObjectVersion"]]]]
+    BucketTagging = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketTagging"]]],
+    ]
+    BucketVersioning = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketVersioning"]]],
+    ]
+    BucketWebsite = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.BucketWebsite"]]],
+    ]
+    MultipartUpload = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.MultipartUpload"]]],
+    ]
+    MultipartUploadPart = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.MultipartUploadPart"]]],
+    ]
+    Object = Annotated[
+        ServiceResource, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Object"]]]
+    ]
+    ObjectAcl = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ObjectAcl"]]],
+    ]
+    ObjectSummary = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ObjectSummary"]]],
+    ]
+    ObjectVersion = Annotated[
+        ServiceResource,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.ObjectVersion"]]],
+    ]
     ServiceResourceBucketsCollection = Annotated[
-        ResourceCollection, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.bucketsCollection"]]]
+        ResourceCollection,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.bucketsCollection"]]],
     ]
     BucketMultipartUploadsCollection = Annotated[
-        ResourceCollection, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Bucket.multipart_uploadsCollection"]]]
+        ResourceCollection,
+        IsAttr[
+            "__class__",
+            IsAttr["__name__", IsEqual["s3.Bucket.multipart_uploadsCollection"]],
+        ],
     ]
     BucketObjectVersionsCollection = Annotated[
-        ResourceCollection, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Bucket.object_versionsCollection"]]]
+        ResourceCollection,
+        IsAttr[
+            "__class__",
+            IsAttr["__name__", IsEqual["s3.Bucket.object_versionsCollection"]],
+        ],
     ]
     BucketObjectsCollection = Annotated[
-        ResourceCollection, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Bucket.objectsCollection"]]]
+        ResourceCollection,
+        IsAttr["__class__", IsAttr["__name__", IsEqual["s3.Bucket.objectsCollection"]]],
     ]
     MultipartUploadPartsCollection = Annotated[
-        ResourceCollection, IsAttr["__class__", IsAttr["__name__", IsEqual["s3.MultipartUpload.partsCollection"]]]
+        ResourceCollection,
+        IsAttr[
+            "__class__",
+            IsAttr["__name__", IsEqual["s3.MultipartUpload.partsCollection"]],
+        ],
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pylint.messages_control]
-max-line-size = 120
-
 disable = [
     "missing-module-docstring",
     "missing-function-docstring"
 ]
-
-[tool.pylint.MASTER]
-ignore-patterns = [
-    "tests/**/*.py"
-]
-
-[tool.black]
-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ moto = {extras = ["all"], version = "^2.2.14"}
 boto3-stubs = {extras = ["all"], version = "^1.20.5"}
 pytest-cov = "^3.0.0"
 
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 
-import boto3
 import pytest
 
 from s3.s3_fixtures import *
@@ -8,8 +7,9 @@ from utils import random_str
 
 AWS_REGION = "us-east-1"  # Moto requires a valid AWS region
 
+
 @pytest.fixture
 def aws_setup():
-    os.putenv("AWS_ACCESS_KEY_ID", random_str())
-    os.putenv("AWS_SECRET_ACCESS_KEY", random_str())
-    os.putenv("AWS_DEFAULT_REGION", AWS_REGION)
+    os.environ["AWS_ACCESS_KEY_ID"] = random_str()
+    os.environ["AWS_SECRET_ACCESS_KEY"] = random_str()
+    os.environ["AWS_DEFAULT_REGION"] = AWS_REGION

--- a/tests/s3/s3_fixtures.py
+++ b/tests/s3/s3_fixtures.py
@@ -8,164 +8,211 @@ from tests.utils import random_str
 MIN_MULTIPART_NUM = 1
 MAX_MULTIPART_NUM = 10000
 
+
 @pytest.fixture
 def s3_client(aws_setup):
     with mock_s3():
-        yield boto3.client('s3')
+        yield boto3.client("s3")
+
 
 @pytest.fixture
 def s3_resource(aws_setup):
     with mock_s3():
-        yield boto3.resource('s3')
+        yield boto3.resource("s3")
+
 
 # ============================
 # MULTIPART
 # ============================
 
+
 @pytest.fixture
 def gen_multipart_upload(s3_resource):
     return s3_resource.MultipartUpload(random_str(), random_str(), random_str())
 
+
 @pytest.fixture
 def gen_multipart_upload_part(s3_resource):
-    return s3_resource.MultipartUploadPart(random_str(), random_str(), random_str(), random.randint(MIN_MULTIPART_NUM, MAX_MULTIPART_NUM))
+    return s3_resource.MultipartUploadPart(
+        random_str(),
+        random_str(),
+        random_str(),
+        random.randint(MIN_MULTIPART_NUM, MAX_MULTIPART_NUM),
+    )
+
 
 # ============================
 # OBJECT
 # ============================
 
+
 @pytest.fixture
 def gen_object(s3_resource):
     return s3_resource.Object(random_str(), random_str())
+
 
 @pytest.fixture
 def gen_object_acl(s3_resource):
     return s3_resource.ObjectAcl(random_str(), random_str())
 
+
 @pytest.fixture
 def gen_object_summary(s3_resource):
     return s3_resource.ObjectSummary(random_str(), random_str())
+
 
 @pytest.fixture
 def gen_object_version(s3_resource):
     return s3_resource.ObjectVersion(random_str(), random_str(), random_str())
 
+
 # ============================
 # WAITER
 # ============================
 
+
 @pytest.fixture
 def gen_bucket_exists_waiter(s3_client):
-    return s3_client.get_waiter('bucket_exists')
+    return s3_client.get_waiter("bucket_exists")
+
 
 @pytest.fixture
 def gen_bucket_not_exists_waiter(s3_client):
-    return s3_client.get_waiter('bucket_not_exists')
+    return s3_client.get_waiter("bucket_not_exists")
+
 
 @pytest.fixture
 def gen_object_exists_waiter(s3_client):
-    return s3_client.get_waiter('object_exists')
+    return s3_client.get_waiter("object_exists")
+
 
 @pytest.fixture
 def gen_object_not_exists_waiter(s3_client):
-    return s3_client.get_waiter('object_not_exists')
+    return s3_client.get_waiter("object_not_exists")
+
 
 # ============================
 # PAGINATOR
 # ============================
 
+
 @pytest.fixture
 def gen_list_multipart_uploads_paginator(s3_client):
-    return s3_client.get_paginator('list_multipart_uploads')
+    return s3_client.get_paginator("list_multipart_uploads")
+
 
 @pytest.fixture
 def get_list_object_versions_paginator(s3_client):
-    return s3_client.get_paginator('list_object_versions')
+    return s3_client.get_paginator("list_object_versions")
+
 
 @pytest.fixture
 def gen_list_objects_paginator(s3_client):
-    return s3_client.get_paginator('list_objects')
+    return s3_client.get_paginator("list_objects")
+
 
 @pytest.fixture
 def gen_list_objects_v2_paginator(s3_client):
-    return s3_client.get_paginator('list_objects_v2')
+    return s3_client.get_paginator("list_objects_v2")
+
 
 @pytest.fixture
 def gen_list_parts_paginator(s3_client):
-    return s3_client.get_paginator('list_parts')
+    return s3_client.get_paginator("list_parts")
+
 
 # ============================
 # COLLECTIONS
 # ============================
 
+
 @pytest.fixture
 def gen_buckets_collection(s3_resource):
     return s3_resource.buckets.all()
+
 
 @pytest.fixture
 def gen_bucket_multipart_uploads_collection(gen_bucket):
     return gen_bucket.multipart_uploads.all()
 
+
 @pytest.fixture
 def gen_multipart_upload_parts_collection(s3_resource):
-    multipart_upload = s3_resource.MultipartUpload(random_str(), random_str(), random_str())
+    multipart_upload = s3_resource.MultipartUpload(
+        random_str(), random_str(), random_str()
+    )
     return multipart_upload.parts.all()
+
 
 @pytest.fixture
 def gen_bucket_objects_collection(gen_bucket):
     return gen_bucket.objects.all()
 
+
 @pytest.fixture
 def gen_bucket_object_versions_collection(gen_bucket):
     return gen_bucket.object_versions.all()
+
 
 # ============================
 # BUCKET
 # ============================
 
+
 @pytest.fixture
 def gen_bucket(s3_resource):
     return s3_resource.create_bucket(Bucket=random_str())
+
 
 @pytest.fixture
 def gen_bucket_acl(s3_resource):
     return s3_resource.BucketAcl(random_str())
 
+
 @pytest.fixture
 def gen_bucket_cors(s3_resource):
     return s3_resource.BucketCors(random_str())
+
 
 @pytest.fixture
 def gen_bucket_lifecycle(s3_resource):
     return s3_resource.BucketLifecycle(random_str())
 
+
 @pytest.fixture
 def gen_bucket_lifecycle_configuration(s3_resource):
     return s3_resource.BucketLifecycleConfiguration(random_str())
+
 
 @pytest.fixture
 def gen_bucket_logging(s3_resource):
     return s3_resource.BucketLogging(random_str())
 
+
 @pytest.fixture
 def gen_bucket_notification(s3_resource):
     return s3_resource.BucketNotification(random_str())
+
 
 @pytest.fixture
 def gen_bucket_policy(s3_resource):
     return s3_resource.BucketPolicy(random_str())
 
+
 @pytest.fixture
 def gen_bucket_request_payment(s3_resource):
     return s3_resource.BucketRequestPayment(random_str())
+
 
 @pytest.fixture
 def gen_bucket_tagging(s3_resource):
     return s3_resource.BucketTagging(random_str())
 
+
 @pytest.fixture
 def gen_bucket_versioning(s3_resource):
     return s3_resource.BucketVersioning(random_str())
+
 
 @pytest.fixture
 def gen_bucket_website(s3_resource):

--- a/tests/s3/test_s3.py
+++ b/tests/s3/test_s3.py
@@ -1,136 +1,192 @@
 import boto3
 import pytest
-from bearboto3.s3 import (MultipartUpload, MultipartUploadPart, S3Client,
-                          S3ServiceResource)
+from bearboto3.s3 import (
+    MultipartUpload,
+    MultipartUploadPart,
+    S3Client,
+    S3ServiceResource,
+)
 from beartype import beartype
-from beartype.roar import (BeartypeCallHintPepParamException,
-                           BeartypeCallHintPepReturnException,
-                           BeartypeDecorHintPep484585Exception)
+from beartype.roar import (
+    BeartypeCallHintPepParamException,
+    BeartypeCallHintPepReturnException,
+    BeartypeDecorHintPep484585Exception,
+)
 from moto import mock_ec2, mock_s3
-from tests.utils import random_str
 
 # ============================
 # CLIENT
 # ============================
 
+
 def test_s3_client_arg_pass(s3_client):
     @beartype
     def func(client: S3Client):
         pass
+
     func(s3_client)
+
 
 def test_s3_client_arg_fail(aws_setup):
     with mock_ec2():
         with pytest.raises(BeartypeCallHintPepParamException):
+
             @beartype
             def func(client: S3Client):
                 pass
-            func(boto3.client('ec2'))
+
+            func(boto3.client("ec2"))
+
 
 def test_s3_client_return_pass(aws_setup):
     @beartype
     def func() -> S3Client:
         with mock_s3():
-            return boto3.client('s3')
+            return boto3.client("s3")
+
     client = func()
 
+
 def test_s3_client_return_fail(aws_setup):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> S3Client:
             with mock_ec2():
-                yield boto3.client('ec2')
+                yield boto3.client("ec2")
+
         client = func()
+
 
 # ============================
 # RESOURCE
 # ============================
 
+
 def test_s3_resource_arg_pass(s3_resource):
     @beartype
     def func(resource: S3ServiceResource):
         pass
+
     func(s3_resource)
+
 
 def test_s3_resource_arg_fail(aws_setup):
     with mock_ec2():
         with pytest.raises(BeartypeCallHintPepParamException):
+
             @beartype
             def func(client: S3ServiceResource):
                 pass
-            func(boto3.resource('ec2'))
+
+            func(boto3.resource("ec2"))
+
 
 def test_s3_resource_return_pass(aws_setup):
     @beartype
     def func() -> S3ServiceResource:
         with mock_s3():
-            return boto3.resource('s3')
+            return boto3.resource("s3")
+
     resource = func()
 
+
 def test_s3_resource_return_fail(aws_setup):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> S3ServiceResource:
             with mock_ec2():
-                yield boto3.resource('ec2')
+                yield boto3.resource("ec2")
+
         resource = func()
+
 
 # ============================
 # MULTIPART UPLOAD
 # ============================
 
+
 def test_multipart_upload_arg_pass(gen_multipart_upload):
     @beartype
     def func(multipart: MultipartUpload):
         pass
+
     func(gen_multipart_upload)
+
 
 def test_multipart_upload_arg_fail(s3_resource):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(multipart: MultipartUpload):
             pass
+
         func(s3_resource)
+
 
 def test_multipart_upload_return_pass(gen_multipart_upload):
     @beartype
     def func() -> MultipartUpload:
         return gen_multipart_upload
+
     multipart = func()
 
+
 def test_multipart_upload_return_fail(s3_resource):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> MultipartUpload:
             return s3_resource
+
         multipart = func()
+
 
 # ============================
 # MULTIPART UPLOAD PART
 # ============================
 
+
 def test_multipart_upload_part_arg_pass(gen_multipart_upload_part):
     @beartype
     def func(multipart: MultipartUploadPart):
         pass
+
     func(gen_multipart_upload_part)
+
 
 def test_multipart_upload_part_arg_fail(s3_resource):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(multipart: MultipartUploadPart):
             pass
+
         func(s3_resource)
+
 
 def test_multipart_upload_part_return_pass(gen_multipart_upload_part):
     @beartype
     def func() -> MultipartUploadPart:
         return gen_multipart_upload_part
+
     multipart = func()
 
+
 def test_multipart_upload_part_return_fail(s3_resource):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> MultipartUploadPart:
             return s3_resource
+
         multipart = func()

--- a/tests/s3/test_s3_bucket.py
+++ b/tests/s3/test_s3_bucket.py
@@ -8,364 +8,518 @@ from beartype import beartype
 from beartype.roar import (BeartypeCallHintPepParamException,
                            BeartypeCallHintPepReturnException,
                            BeartypeDecorHintPep484585Exception)
-from tests.utils import random_str
 
 # ============================
 # BUCKET
 # ============================
 
+
 def test_bucket_arg_pass(gen_bucket):
     @beartype
     def func(param: Bucket):
         pass
+
     func(gen_bucket)
+
 
 def test_bucket_arg_fail(gen_bucket_acl):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: Bucket):
             pass
+
         func(gen_bucket_acl)
+
 
 def test_bucket_return_pass(gen_bucket):
     @beartype
     def func() -> Bucket:
         return gen_bucket
+
     param = func()
 
+
 def test_bucket_return_fail(gen_bucket_acl):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> Bucket:
             return gen_bucket_acl
+
         param = func()
+
 
 # ============================
 # BUCKET ACL
 # ============================
 
+
 def test_bucket_acl_arg_pass(gen_bucket_acl):
     @beartype
     def func(param: BucketAcl):
         pass
+
     func(gen_bucket_acl)
+
 
 def test_bucket_acl_arg_fail(gen_bucket):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketAcl):
             pass
+
         func(gen_bucket)
+
 
 def test_bucket_acl_return_pass(gen_bucket_acl):
     @beartype
     def func() -> BucketAcl:
         return gen_bucket_acl
+
     param = func()
 
+
 def test_bucket_acl_return_fail(gen_bucket):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketAcl:
             return gen_bucket
+
         param = func()
+
 
 # ============================
 # BUCKET CORS
 # ============================
 
+
 def test_bucket_cors_arg_pass(gen_bucket_cors):
     @beartype
     def func(param: BucketCors):
         pass
+
     func(gen_bucket_cors)
+
 
 def test_bucket_cors_arg_fail(gen_bucket):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketCors):
             pass
+
         func(gen_bucket)
+
 
 def test_bucket_cors_return_pass(gen_bucket_cors):
     @beartype
     def func() -> BucketCors:
         return gen_bucket_cors
+
     param = func()
 
+
 def test_bucket_cors_return_fail(gen_bucket):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketCors:
             return gen_bucket
+
         param = func()
+
 
 # ============================
 # BUCKET LIFECYCLE
 # ============================
 
+
 def test_bucket_lifecycle_arg_pass(gen_bucket_lifecycle):
     @beartype
     def func(param: BucketLifecycle):
         pass
+
     func(gen_bucket_lifecycle)
+
 
 def test_bucket_lifecycle_arg_fail(gen_bucket_lifecycle_configuration):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketLifecycle):
             pass
+
         func(gen_bucket_lifecycle_configuration)
+
 
 def test_bucket_lifecycle_return_pass(gen_bucket_lifecycle):
     @beartype
     def func() -> BucketLifecycle:
         return gen_bucket_lifecycle
+
     param = func()
 
+
 def test_bucket_lifecycle_return_fail(gen_bucket_lifecycle_configuration):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketLifecycle:
             return gen_bucket_lifecycle_configuration
+
         param = func()
+
 
 # ===============================
 # BUCKET LIFECYCLE CONFIGURATION
 # ===============================
 
+
 def test_bucket_lifecycle_configuration_arg_pass(gen_bucket_lifecycle_configuration):
     @beartype
     def func(param: BucketLifecycleConfiguration):
         pass
+
     func(gen_bucket_lifecycle_configuration)
+
 
 def test_bucket_lifecycle_configuration_arg_fail(gen_bucket_lifecycle):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketLifecycleConfiguration):
             pass
+
         func(gen_bucket_lifecycle)
+
 
 def test_bucket_lifecycle_configuration_return_pass(gen_bucket_lifecycle_configuration):
     @beartype
     def func() -> BucketLifecycleConfiguration:
         return gen_bucket_lifecycle_configuration
+
     param = func()
 
+
 def test_bucket_lifecycle_configuration_return_fail(gen_bucket_lifecycle):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketLifecycleConfiguration:
             return gen_bucket_lifecycle
+
         param = func()
+
 
 # ============================
 # BUCKET LOGGING
 # ============================
 
+
 def test_bucket_logging_arg_pass(gen_bucket_logging):
     @beartype
     def func(param: BucketLogging):
         pass
+
     func(gen_bucket_logging)
+
 
 def test_bucket_logging_arg_fail(gen_bucket_notification):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketLogging):
             pass
+
         func(gen_bucket_notification)
+
 
 def test_bucket_logging_return_pass(gen_bucket_logging):
     @beartype
     def func() -> BucketLogging:
         return gen_bucket_logging
+
     param = func()
 
+
 def test_bucket_logging_return_fail(gen_bucket_notification):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketLogging:
             return gen_bucket_notification
+
         param = func()
+
 
 # ============================
 # BUCKET NOTIFICATION
 # ============================
 
+
 def test_bucket_notification_arg_pass(gen_bucket_notification):
     @beartype
     def func(param: BucketNotification):
         pass
+
     func(gen_bucket_notification)
+
 
 def test_bucket_notification_arg_fail(gen_bucket_logging):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketNotification):
             pass
+
         func(gen_bucket_logging)
+
 
 def test_bucket_notification_return_pass(gen_bucket_notification):
     @beartype
     def func() -> BucketNotification:
         return gen_bucket_notification
+
     param = func()
 
+
 def test_bucket_notification_return_fail(gen_bucket_logging):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketNotification:
             return gen_bucket_logging
+
         param = func()
+
 
 # ============================
 # BUCKET POLICY
 # ============================
 
+
 def test_bucket_policy_arg_pass(gen_bucket_policy):
     @beartype
     def func(param: BucketPolicy):
         pass
+
     func(gen_bucket_policy)
+
 
 def test_bucket_policy_arg_fail(gen_bucket_request_payment):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketPolicy):
             pass
+
         func(gen_bucket_request_payment)
+
 
 def test_bucket_policy_return_pass(gen_bucket_policy):
     @beartype
     def func() -> BucketPolicy:
         return gen_bucket_policy
+
     param = func()
 
+
 def test_bucket_policy_return_fail(gen_bucket_request_payment):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketPolicy:
             return gen_bucket_request_payment
+
         param = func()
+
 
 # ============================
 # BUCKET REQUEST PAYMENT
 # ============================
 
+
 def test_bucket_request_payment_arg_pass(gen_bucket_request_payment):
     @beartype
     def func(param: BucketRequestPayment):
         pass
+
     func(gen_bucket_request_payment)
+
 
 def test_bucket_request_payment_arg_fail(gen_bucket_policy):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketRequestPayment):
             pass
+
         func(gen_bucket_policy)
+
 
 def test_bucket_request_payment_return_pass(gen_bucket_request_payment):
     @beartype
     def func() -> BucketRequestPayment:
         return gen_bucket_request_payment
+
     param = func()
 
+
 def test_bucket_request_payment_return_fail(gen_bucket_policy):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketRequestPayment:
             return gen_bucket_policy
+
         param = func()
+
 
 # ============================
 # BUCKET TAGGING
 # ============================
 
+
 def test_bucket_tagging_arg_pass(gen_bucket_tagging):
     @beartype
     def func(param: BucketTagging):
         pass
+
     func(gen_bucket_tagging)
+
 
 def test_bucket_tagging_arg_fail(gen_bucket_versioning):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketTagging):
             pass
+
         func(gen_bucket_versioning)
+
 
 def test_bucket_tagging_return_pass(gen_bucket_tagging):
     @beartype
     def func() -> BucketTagging:
         return gen_bucket_tagging
+
     param = func()
 
+
 def test_bucket_tagging_return_fail(gen_bucket_versioning):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketTagging:
             return gen_bucket_versioning
+
         param = func()
+
 
 # ============================
 # BUCKET VERSIONING
 # ============================
 
+
 def test_bucket_versioning_arg_pass(gen_bucket_versioning):
     @beartype
     def func(param: BucketVersioning):
         pass
+
     func(gen_bucket_versioning)
+
 
 def test_bucket_versioning_arg_fail(gen_bucket_tagging):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketVersioning):
             pass
+
         func(gen_bucket_tagging)
+
 
 def test_bucket_versioning_return_pass(gen_bucket_versioning):
     @beartype
     def func() -> BucketVersioning:
         return gen_bucket_versioning
+
     param = func()
 
+
 def test_bucket_versioning_return_fail(gen_bucket_tagging):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketVersioning:
             return gen_bucket_tagging
+
         param = func()
+
 
 # ============================
 # BUCKET WEBSITE
 # ============================
 
+
 def test_bucket_website_arg_pass(gen_bucket_website):
     @beartype
     def func(param: BucketWebsite):
         pass
+
     func(gen_bucket_website)
+
 
 def test_bucket_website_arg_fail(gen_bucket):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketWebsite):
             pass
+
         func(gen_bucket)
+
 
 def test_bucket_website_return_pass(gen_bucket_website):
     @beartype
     def func() -> BucketWebsite:
         return gen_bucket_website
+
     param = func()
 
+
 def test_bucket_website_return_fail(gen_bucket):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketWebsite:
             return gen_bucket
+
         param = func()

--- a/tests/s3/test_s3_collections.py
+++ b/tests/s3/test_s3_collections.py
@@ -1,161 +1,249 @@
 import pytest
-from bearboto3.s3 import (BucketMultipartUploadsCollection,
-                          BucketObjectsCollection,
-                          BucketObjectVersionsCollection,
-                          MultipartUploadPartsCollection,
-                          ServiceResourceBucketsCollection)
+from bearboto3.s3 import (
+    BucketMultipartUploadsCollection,
+    BucketObjectsCollection,
+    BucketObjectVersionsCollection,
+    MultipartUploadPartsCollection,
+    ServiceResourceBucketsCollection,
+)
 from beartype import beartype
-from beartype.roar import (BeartypeCallHintPepParamException,
-                           BeartypeCallHintPepReturnException,
-                           BeartypeDecorHintPep484585Exception)
+from beartype.roar import (
+    BeartypeCallHintPepParamException,
+    BeartypeCallHintPepReturnException,
+    BeartypeDecorHintPep484585Exception,
+)
 from tests.utils import random_str
 
 # ============================
 # BUCKETS
 # ============================
 
+
 def test_buckets_collection_arg_pass(gen_buckets_collection):
     @beartype
     def func(collection: ServiceResourceBucketsCollection):
         pass
+
     func(gen_buckets_collection)
+
 
 def test_buckets_collection_arg_fail(gen_bucket_objects_collection):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: ServiceResourceBucketsCollection):
             pass
+
         func(gen_bucket_objects_collection)
+
 
 def test_buckets_collection_return_pass(gen_buckets_collection):
     @beartype
     def func() -> ServiceResourceBucketsCollection:
         return gen_buckets_collection
+
     param = func()
 
+
 def test_buckets_collection_return_fail(gen_bucket_objects_collection):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ServiceResourceBucketsCollection:
             return gen_bucket_objects_collection
+
         param = func()
+
 
 # ============================
 # BUCKET MULTIPART UPLOADS
 # ============================
 
-def test_bucket_multipart_uploads_collection_arg_pass(gen_bucket_multipart_uploads_collection):
+
+def test_bucket_multipart_uploads_collection_arg_pass(
+    gen_bucket_multipart_uploads_collection,
+):
     @beartype
     def func(collection: BucketMultipartUploadsCollection):
         pass
+
     func(gen_bucket_multipart_uploads_collection)
 
-def test_bucket_multipart_uploads_collection_arg_fail(gen_multipart_upload_parts_collection):
+
+def test_bucket_multipart_uploads_collection_arg_fail(
+    gen_multipart_upload_parts_collection,
+):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketMultipartUploadsCollection):
             pass
+
         func(gen_multipart_upload_parts_collection)
 
-def test_bucket_multipart_uploads_collection_return_pass(gen_bucket_multipart_uploads_collection):
+
+def test_bucket_multipart_uploads_collection_return_pass(
+    gen_bucket_multipart_uploads_collection,
+):
     @beartype
     def func() -> BucketMultipartUploadsCollection:
         return gen_bucket_multipart_uploads_collection
+
     param = func()
 
-def test_bucket_multipart_uploads_collection_return_fail(gen_multipart_upload_parts_collection):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+
+def test_bucket_multipart_uploads_collection_return_fail(
+    gen_multipart_upload_parts_collection,
+):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketMultipartUploadsCollection:
             return gen_multipart_upload_parts_collection
+
         param = func()
+
 
 # ============================
 # MULTIPART UPLOAD PARTS
 # ============================
 
-def test_multipart_upload_parts_collection_arg_pass(gen_multipart_upload_parts_collection):
+
+def test_multipart_upload_parts_collection_arg_pass(
+    gen_multipart_upload_parts_collection,
+):
     @beartype
     def func(collection: MultipartUploadPartsCollection):
         pass
+
     func(gen_multipart_upload_parts_collection)
 
-def test_multipart_upload_parts_collection_arg_fail(gen_bucket_multipart_uploads_collection):
+
+def test_multipart_upload_parts_collection_arg_fail(
+    gen_bucket_multipart_uploads_collection,
+):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: MultipartUploadPartsCollection):
             pass
+
         func(gen_bucket_multipart_uploads_collection)
 
-def test_multipart_upload_parts_collection_return_pass(gen_multipart_upload_parts_collection):
+
+def test_multipart_upload_parts_collection_return_pass(
+    gen_multipart_upload_parts_collection,
+):
     @beartype
     def func() -> MultipartUploadPartsCollection:
         return gen_multipart_upload_parts_collection
+
     param = func()
 
-def test_multipart_upload_parts_collection_return_fail(gen_bucket_multipart_uploads_collection):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+
+def test_multipart_upload_parts_collection_return_fail(
+    gen_bucket_multipart_uploads_collection,
+):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> MultipartUploadPartsCollection:
             return gen_bucket_multipart_uploads_collection
+
         param = func()
+
 
 # ============================
 # BUCKET OBJECTS
 # ============================
 
+
 def test_bucket_objects_collection_arg_pass(gen_bucket_objects_collection):
     @beartype
     def func(collection: BucketObjectsCollection):
         pass
+
     func(gen_bucket_objects_collection)
+
 
 def test_bucket_objects_collection_arg_fail(gen_bucket_object_versions_collection):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketObjectsCollection):
             pass
+
         func(gen_bucket_object_versions_collection)
+
 
 def test_bucket_objects_collection_return_pass(gen_bucket_objects_collection):
     @beartype
     def func() -> BucketObjectsCollection:
         return gen_bucket_objects_collection
+
     param = func()
 
+
 def test_bucket_objects_collection_return_fail(gen_bucket_object_versions_collection):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketObjectsCollection:
             return gen_bucket_object_versions_collection
+
         param = func()
+
 
 # ============================
 # BUCKET OBJECT VERSIONS
 # ============================
 
-def test_bucket_object_versions_collection_arg_pass(gen_bucket_object_versions_collection):
+
+def test_bucket_object_versions_collection_arg_pass(
+    gen_bucket_object_versions_collection,
+):
     @beartype
     def func(collection: BucketObjectVersionsCollection):
         pass
+
     func(gen_bucket_object_versions_collection)
+
 
 def test_bucket_object_versions_collection_arg_fail(gen_bucket_objects_collection):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(param: BucketObjectVersionsCollection):
             pass
+
         func(gen_bucket_objects_collection)
 
-def test_bucket_object_versions_collection_return_pass(gen_bucket_object_versions_collection):
+
+def test_bucket_object_versions_collection_return_pass(
+    gen_bucket_object_versions_collection,
+):
     @beartype
     def func() -> BucketObjectVersionsCollection:
         return gen_bucket_object_versions_collection
+
     param = func()
 
+
 def test_bucket_object_versions_collection_return_fail(gen_bucket_objects_collection):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketObjectVersionsCollection:
             return gen_bucket_objects_collection
+
         param = func()

--- a/tests/s3/test_s3_object.py
+++ b/tests/s3/test_s3_object.py
@@ -1,126 +1,179 @@
 import pytest
 from bearboto3.s3 import Object, ObjectAcl, ObjectSummary, ObjectVersion
 from beartype import beartype
-from beartype.roar import (BeartypeCallHintPepParamException,
-                           BeartypeCallHintPepReturnException,
-                           BeartypeDecorHintPep484585Exception)
+from beartype.roar import (
+    BeartypeCallHintPepParamException,
+    BeartypeCallHintPepReturnException,
+    BeartypeDecorHintPep484585Exception,
+)
 
 # ============================
 # OBJECT
 # ============================
 
+
 def test_object_arg_pass(gen_object):
     @beartype
     def func(obj: Object):
         pass
+
     func(gen_object)
+
 
 def test_object_arg_fail(s3_resource):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(obj: Object):
             pass
+
         func(s3_resource)
+
 
 def test_object_return_pass(gen_object):
     @beartype
     def func() -> Object:
         return gen_object
+
     obj = func()
 
+
 def test_object_return_fail(s3_resource):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> Object:
             return s3_resource
+
         obj = func()
+
 
 # ============================
 # OBJECT ACL
 # ============================
 
+
 def test_object_acl_arg_pass(gen_object_acl):
     @beartype
     def func(obj: ObjectAcl):
         pass
+
     func(gen_object_acl)
+
 
 def test_object_acl_arg_fail(s3_resource):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(obj: ObjectAcl):
             pass
+
         func(s3_resource)
+
 
 def test_object_acl_return_pass(gen_object_acl):
     @beartype
     def func() -> ObjectAcl:
         return gen_object_acl
+
     obj = func()
 
+
 def test_object_acl_return_fail(s3_resource):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ObjectAcl:
             return s3_resource
+
         obj = func()
+
 
 # ============================
 # OBJECT SUMMARY
 # ============================
 
+
 def test_object_summary_arg_pass(gen_object_summary):
     @beartype
     def func(obj: ObjectSummary):
         pass
+
     func(gen_object_summary)
+
 
 def test_object_summary_arg_fail(s3_resource):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(obj: ObjectSummary):
             pass
+
         func(s3_resource)
+
 
 def test_object_summary_return_pass(gen_object_summary):
     @beartype
     def func() -> ObjectSummary:
         return gen_object_summary
+
     obj = func()
 
+
 def test_object_summary_return_fail(s3_resource):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ObjectSummary:
             return s3_resource
+
         obj = func()
+
 
 # ============================
 # OBJECT VERSION
 # ============================
 
+
 def test_object_version_arg_pass(gen_object_version):
     @beartype
     def func(obj: ObjectVersion):
         pass
+
     func(gen_object_version)
+
 
 def test_object_version_arg_fail(s3_resource):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(obj: ObjectVersion):
             pass
+
         func(s3_resource)
+
 
 def test_object_version_return_pass(gen_object_version):
     @beartype
     def func() -> ObjectVersion:
         return gen_object_version
+
     obj = func()
 
+
 def test_object_version_return_fail(s3_resource):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ObjectVersion:
             return s3_resource
+
         obj = func()

--- a/tests/s3/test_s3_paginators.py
+++ b/tests/s3/test_s3_paginators.py
@@ -1,158 +1,234 @@
 import pytest
-from bearboto3.s3 import (ListMultipartUploadsPaginator, ListObjectsPaginator,
-                          ListObjectsV2Paginator, ListObjectVersionsPaginator,
-                          ListPartsPaginator)
+from bearboto3.s3 import (
+    ListMultipartUploadsPaginator,
+    ListObjectsPaginator,
+    ListObjectsV2Paginator,
+    ListObjectVersionsPaginator,
+    ListPartsPaginator,
+)
 from beartype import beartype
-from beartype.roar import (BeartypeCallHintPepParamException,
-                           BeartypeCallHintPepReturnException,
-                           BeartypeDecorHintPep484585Exception)
+from beartype.roar import (
+    BeartypeCallHintPepParamException,
+    BeartypeCallHintPepReturnException,
+    BeartypeDecorHintPep484585Exception,
+)
 
 # ============================
 # MULTIPART
 # ============================
 
+
 def test_list_multipart_uploads_paginator_pass(gen_list_multipart_uploads_paginator):
     @beartype
     def func(paginator: ListMultipartUploadsPaginator):
         pass
+
     func(gen_list_multipart_uploads_paginator)
+
 
 def test_list_multipart_uploads_paginator_arg_fail(get_list_object_versions_paginator):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(paginator: ListMultipartUploadsPaginator):
             pass
+
         func(get_list_object_versions_paginator)
 
-def test_list_multipart_uploads_paginator_return_pass(gen_list_multipart_uploads_paginator):
+
+def test_list_multipart_uploads_paginator_return_pass(
+    gen_list_multipart_uploads_paginator,
+):
     @beartype
     def func() -> ListMultipartUploadsPaginator:
         return gen_list_multipart_uploads_paginator
+
     paginator = func()
 
-def test_list_multipart_uploads_paginator_return_fail(get_list_object_versions_paginator):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+
+def test_list_multipart_uploads_paginator_return_fail(
+    get_list_object_versions_paginator,
+):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ListMultipartUploadsPaginator:
             return get_list_object_versions_paginator
+
         paginator = func()
+
 
 # ============================
 # OBJECT VERSIONS
 # ============================
 
+
 def test_list_object_versions_paginator_pass(get_list_object_versions_paginator):
     @beartype
     def func(paginator: ListObjectVersionsPaginator):
         pass
+
     func(get_list_object_versions_paginator)
+
 
 def test_list_object_versions_paginator_arg_fail(gen_list_multipart_uploads_paginator):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(paginator: ListObjectVersionsPaginator):
             pass
+
         func(gen_list_multipart_uploads_paginator)
+
 
 def test_list_object_versions_paginator_return_pass(get_list_object_versions_paginator):
     @beartype
     def func() -> ListObjectVersionsPaginator:
         return get_list_object_versions_paginator
+
     paginator = func()
 
-def test_list_object_versions_paginator_return_fail(gen_list_multipart_uploads_paginator):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+
+def test_list_object_versions_paginator_return_fail(
+    gen_list_multipart_uploads_paginator,
+):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ListObjectVersionsPaginator:
             return gen_list_multipart_uploads_paginator
+
         paginator = func()
+
 
 # ============================
 # LIST OBJECTS
 # ============================
 
+
 def test_list_objects_paginator_pass(gen_list_objects_paginator):
     @beartype
     def func(paginator: ListObjectsPaginator):
         pass
+
     func(gen_list_objects_paginator)
+
 
 def test_list_objects_paginator_arg_fail(gen_list_objects_v2_paginator):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(paginator: ListObjectsPaginator):
             pass
+
         func(gen_list_objects_v2_paginator)
+
 
 def test_list_objects_paginator_return_pass(gen_list_objects_paginator):
     @beartype
     def func() -> ListObjectsPaginator:
         return gen_list_objects_paginator
+
     paginator = func()
 
+
 def test_list_objects_paginator_return_fail(gen_list_objects_v2_paginator):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ListObjectsPaginator:
             return gen_list_objects_v2_paginator
+
         paginator = func()
+
 
 # ============================
 # LIST OBJECTS V2
 # ============================
 
+
 def test_list_objects_v2_paginator_pass(gen_list_objects_v2_paginator):
     @beartype
     def func(paginator: ListObjectsV2Paginator):
         pass
+
     func(gen_list_objects_v2_paginator)
+
 
 def test_list_objects_v2_paginator_arg_fail(gen_list_objects_paginator):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(paginator: ListObjectsV2Paginator):
             pass
+
         func(gen_list_objects_paginator)
+
 
 def test_list_objects_v2_paginator_return_pass(gen_list_objects_v2_paginator):
     @beartype
     def func() -> ListObjectsV2Paginator:
         return gen_list_objects_v2_paginator
+
     paginator = func()
 
+
 def test_list_objects_v2_paginator_return_fail(gen_list_objects_paginator):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ListObjectsV2Paginator:
             return gen_list_objects_paginator
+
         paginator = func()
+
 
 # ============================
 # LIST PARTS
 # ============================
 
+
 def test_list_parts_paginator_pass(gen_list_parts_paginator):
     @beartype
     def func(paginator: ListPartsPaginator):
         pass
+
     func(gen_list_parts_paginator)
+
 
 def test_list_parts_paginator_arg_fail(gen_list_objects_paginator):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(paginator: ListPartsPaginator):
             pass
+
         func(gen_list_objects_paginator)
+
 
 def test_list_parts_paginator_return_pass(gen_list_parts_paginator):
     @beartype
     def func() -> ListPartsPaginator:
         return gen_list_parts_paginator
+
     paginator = func()
 
+
 def test_list_parts_paginator_return_fail(gen_list_objects_paginator):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ListPartsPaginator:
             return gen_list_objects_paginator
+
         paginator = func()

--- a/tests/s3/test_s3_waiters.py
+++ b/tests/s3/test_s3_waiters.py
@@ -1,127 +1,184 @@
 import pytest
-from bearboto3.s3 import (BucketExistsWaiter, BucketNotExistsWaiter,
-                          ObjectExistsWaiter, ObjectNotExistsWaiter)
+from bearboto3.s3 import (
+    BucketExistsWaiter,
+    BucketNotExistsWaiter,
+    ObjectExistsWaiter,
+    ObjectNotExistsWaiter,
+)
 from beartype import beartype
-from beartype.roar import (BeartypeCallHintPepParamException,
-                           BeartypeCallHintPepReturnException,
-                           BeartypeDecorHintPep484585Exception)
+from beartype.roar import (
+    BeartypeCallHintPepParamException,
+    BeartypeCallHintPepReturnException,
+    BeartypeDecorHintPep484585Exception,
+)
 
 # ============================
 # BUCKET EXISTS
 # ============================
 
+
 def test_bucket_exists_waiter_arg_pass(gen_bucket_exists_waiter):
     @beartype
     def func(waiter: BucketExistsWaiter):
         pass
+
     func(gen_bucket_exists_waiter)
+
 
 def test_bucket_exists_waiter_arg_fail(gen_bucket_not_exists_waiter):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(waiter: BucketExistsWaiter):
             pass
+
         func(gen_bucket_not_exists_waiter)
+
 
 def test_bucket_exists_waiter_return_pass(gen_bucket_exists_waiter):
     @beartype
     def func() -> BucketExistsWaiter:
         return gen_bucket_exists_waiter
+
     waiter = func()
 
+
 def test_bucket_exists_waiter_return_fail(gen_bucket_not_exists_waiter):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketExistsWaiter:
             return gen_bucket_not_exists_waiter
+
         waiter = func()
+
 
 # ============================
 # BUCKET NOT EXISTS
 # ============================
 
+
 def test_bucket_not_exists_waiter_arg_pass(gen_bucket_not_exists_waiter):
     @beartype
     def func(waiter: BucketNotExistsWaiter):
         pass
+
     func(gen_bucket_not_exists_waiter)
+
 
 def test_bucket_not_exists_waiter_arg_fail(gen_bucket_exists_waiter):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(waiter: BucketNotExistsWaiter):
             pass
+
         func(gen_bucket_exists_waiter)
+
 
 def test_bucket_not_exists_waiter_return_pass(gen_bucket_not_exists_waiter):
     @beartype
     def func() -> BucketNotExistsWaiter:
         return gen_bucket_not_exists_waiter
+
     waiter = func()
 
+
 def test_bucket_not_exists_waiter_return_fail(gen_bucket_exists_waiter):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> BucketNotExistsWaiter:
             return gen_bucket_exists_waiter
+
         waiter = func()
+
 
 # ============================
 # OBJECT EXISTS
 # ============================
 
+
 def test_object_exists_waiter_arg_pass(gen_object_exists_waiter):
     @beartype
     def func(waiter: ObjectExistsWaiter):
         pass
+
     func(gen_object_exists_waiter)
+
 
 def test_object_exists_waiter_arg_fail(gen_object_not_exists_waiter):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(waiter: ObjectExistsWaiter):
             pass
+
         func(gen_object_not_exists_waiter)
+
 
 def test_object_exists_waiter_return_pass(gen_object_exists_waiter):
     @beartype
     def func() -> ObjectExistsWaiter:
         return gen_object_exists_waiter
+
     waiter = func()
 
+
 def test_object_exists_waiter_return_fail(gen_object_not_exists_waiter):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ObjectExistsWaiter:
             return gen_object_not_exists_waiter
+
         waiter = func()
+
 
 # ============================
 # OBJECT NOT EXISTS
 # ============================
 
+
 def test_object_not_exists_waiter_arg_pass(gen_object_not_exists_waiter):
     @beartype
     def func(waiter: ObjectNotExistsWaiter):
         pass
+
     func(gen_object_not_exists_waiter)
+
 
 def test_object_not_exists_waiter_arg_fail(gen_object_exists_waiter):
     with pytest.raises(BeartypeCallHintPepParamException):
+
         @beartype
         def func(waiter: ObjectNotExistsWaiter):
             pass
+
         func(gen_object_exists_waiter)
+
 
 def test_object_not_exists_waiter_return_pass(gen_object_not_exists_waiter):
     @beartype
     def func() -> ObjectNotExistsWaiter:
         return gen_object_not_exists_waiter
+
     waiter = func()
 
+
 def test_object_not_exists_waiter_return_fail(gen_object_exists_waiter):
-    with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
+    with pytest.raises(
+        (BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)
+    ):
+
         @beartype
         def func() -> ObjectNotExistsWaiter:
             return gen_object_exists_waiter
+
         waiter = func()

--- a/tests/template.py
+++ b/tests/template.py
@@ -33,11 +33,11 @@ on the test:
 #     @beartype
 #     def func() -> FooType:
 #         return pass_fixture
-#     param = func()
+#     result = func()
 
 # def test_foo_type_return_fail(fail_fixture):
 #     with pytest.raises((BeartypeCallHintPepReturnException, BeartypeDecorHintPep484585Exception)):
 #         @beartype
 #         def func() -> FooType:
 #             return fail_fixture
-#         param = func()
+#         result = func()


### PR DESCRIPTION
Adds support for the following S3 types from boto3:

- [`S3Client`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#client)
- [`S3ServiceResource`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#service-resource)
- [`Bucket`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucket)
- [`BucketAcl`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketacl)
- [`BucketCors`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketcors)
- [`BucketLifecycle`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketlifecycle)
- [`BucketLifecycleConfiguration`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketlifecycleconfiguration)
- [`BucketLogging`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketlogging)
- [`BucketNotification`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketnotification)
- [`BucketPolicy`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketpolicy)
- [`BucketRequestPayment`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketrequestpayment)
- [`BucketTagging`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#buckettagging)
- [`BucketVersioning`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketversioning)
- [`BucketWebsite`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucketwebsite)
- [`MultipartUpload`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#multipartupload)
- [`MultipartUploadPart`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#multipartuploadpart)
- [`Object`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#object)
- [`ObjectAcl`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#objectacl)
- [`ObjectSummary`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#objectsummary)
- [`ObjectVersion`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#objectversion)
- [`ListMultipartUploadsPaginator`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Paginator.ListMultipartUploads)
- [`ListObjectVersionsPaginator`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Paginator.ListObjectVersions)
- [`ListObjectsPaginator`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Paginator.ListObjects)
- [`ListObjectsV2Paginator`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Paginator.ListObjectsV2)
- [`ListPartsPaginator`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Paginator.ListParts)
- [`BucketExistsWaiter`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Waiter.BucketExists)
- [`BucketNotExistsWaiter`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Waiter.BucketNotExists)
- [`ObjectExistsWaiter`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Waiter.ObjectExists)
- [`ObjectNotExistsWaiter`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Waiter.ObjectNotExists)
- [`ServiceResourceBucketsCollection`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.ServiceResource.buckets)
- [`BucketMultipartUploadsCollection`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.multipart_uploads)
- [`BucketObjectVersionsCollection`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.object_versions)
- [`BucketObjectsCollection`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Bucket.objects)
- [`MultipartUploadPartsCollection`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.MultipartUpload.parts)

This MR also sets the foundation examples for testing, and a template for writing future unit tests.